### PR TITLE
[update] プレースホルダー画像をS3の実際のサンプル画像に置き換え

### DIFF
--- a/src/app/history/[id]/page.tsx
+++ b/src/app/history/[id]/page.tsx
@@ -25,9 +25,9 @@ const teaParties: TeaParty[] = [
     title: "新緑の茶会",
     description: "桜の香り漂う、静寂の一服",
     imageUrls: [
-      "/placeholder.svg?height=600&width=800&text=新緑の茶会1",
-      "/placeholder.svg?height=600&width=800&text=新緑の茶会2",
-      "/placeholder.svg?height=600&width=800&text=新緑の茶会3",
+      "https://tea-app-sample-pic.s3.ap-northeast-1.amazonaws.com/tea-app-sample-state-1.jpg",
+      "https://tea-app-sample-pic.s3.ap-northeast-1.amazonaws.com/tea-app-sample-state-2.jpg",
+      "https://tea-app-sample-pic.s3.ap-northeast-1.amazonaws.com/tea-app-sample-state-3.jpg",
     ],
     fullDescription: "新緑の候、桜花の舞う中での趣深い茶会を催します。床の間には季節の掛け軸と春の花を飾り、茶室から望む日本庭園の景色と共に、点てたての抹茶と主菓子をお楽しみください。茶道の作法を通じて、和の心に触れる静謐なひとときをご用意いたしました。",
     date: "2024年4月5日",
@@ -39,9 +39,9 @@ const teaParties: TeaParty[] = [
     title: "七夕茶会",
     description: "星月夜に愉しむ夜茶の会",
     imageUrls: [
-      "/placeholder.svg?height=600&width=800&text=七夕茶会1",
-      "/placeholder.svg?height=600&width=800&text=七夕茶会2",
-      "/placeholder.svg?height=600&width=800&text=七夕茶会3",
+      "https://tea-app-sample-pic.s3.ap-northeast-1.amazonaws.com/tea-app-sample-state-1.jpg",
+      "https://tea-app-sample-pic.s3.ap-northeast-1.amazonaws.com/tea-app-sample-state-2.jpg",
+      "https://tea-app-sample-pic.s3.ap-northeast-1.amazonaws.com/tea-app-sample-state-3.jpg",
     ],
     fullDescription: "七夕の宵に、竹飾りの揺らめく灯りの下で開かれる趣向を凝らした茶会です。涼やかな夏の夜風を感じながら、季節の和菓子と共に薄茶を楽しみ、短冊に願いを込めて。茶室では笹の葉の飾りと共に、夏の夜の情緒をお楽しみください。",
     date: "2024年7月7日",
@@ -53,9 +53,9 @@ const teaParties: TeaParty[] = [
     title: "中国茶藝の会",
     description: "千年の歴史が紡ぐ茶の世界",
     imageUrls: [
-      "/placeholder.svg?height=600&width=800&text=中国茶藝1",
-      "/placeholder.svg?height=600&width=800&text=中国茶藝2",
-      "/placeholder.svg?height=600&width=800&text=中国茶藝3",
+      "https://tea-app-sample-pic.s3.ap-northeast-1.amazonaws.com/tea-app-sample-state-1.jpg",
+      "https://tea-app-sample-pic.s3.ap-northeast-1.amazonaws.com/tea-app-sample-state-2.jpg",
+      "https://tea-app-sample-pic.s3.ap-northeast-1.amazonaws.com/tea-app-sample-state-3.jpg",
     ],
     fullDescription: "古来より伝わる中国茶藝の真髄に触れる特別な会。厳選された烏龍茶や工夫紅茶を、伝統的な茶器を用いて味わいます。茶葉の移ろいゆく香りと味わいを、点茶の所作と共にご堪能ください。茶席では、中国茶文化の奥深さについても解説いたします。",
     date: "2024年6月10日",
@@ -67,9 +67,9 @@ const teaParties: TeaParty[] = [
     title: "涼煎茶の会",
     description: "清涼な一煎に夏の暑さを忘れる",
     imageUrls: [
-      "/placeholder.svg?height=600&width=800&text=涼煎茶の会1",
-      "/placeholder.svg?height=600&width=800&text=涼煎茶の会2",
-      "/placeholder.svg?height=600&width=800&text=涼煎茶の会3",
+      "https://tea-app-sample-pic.s3.ap-northeast-1.amazonaws.com/tea-app-sample-state-1.jpg",
+      "https://tea-app-sample-pic.s3.ap-northeast-1.amazonaws.com/tea-app-sample-state-2.jpg",
+      "https://tea-app-sample-pic.s3.ap-northeast-1.amazonaws.com/tea-app-sample-state-3.jpg",
     ],
     fullDescription: "真夏の暑さを忘れさせる、涼を誘う煎茶の会。八十八夜摘みの新茶や、玉露の冷茶を中心に、季節の干菓子と共にお楽しみいただきます。涼やかな茶器の音色に耳を傾けながら、日本の夏の風情をお楽しみください。茶席からは、川のせせらぎも聞こえます。",
     date: "2024年8月15日",
@@ -117,7 +117,7 @@ export default function TeaPartyDetail() {
       transition={{ duration: 0.5 }}
       className="container mx-auto px-4 py-8"
     >
-      <Link href="/" className="text-green-600 hover:underline mb-4 inline-block">&larr; 戻る</Link>
+      <Link href="/history" className="text-green-600 hover:underline mb-4 inline-block">&larr; 戻る</Link>
       <div className="bg-white rounded-lg shadow-lg overflow-hidden">
         <div className="relative h-96 w-full">
           <Image

--- a/src/components/TeaPartyGallery.tsx
+++ b/src/components/TeaPartyGallery.tsx
@@ -11,10 +11,10 @@ type TeaParty = {
 }
 
 const teaParties: TeaParty[] = [
-  { id: 1, title: "新緑の茶会", description: "桜の香り漂う、静寂の一服", imageUrl: "/placeholder.svg?height=600&width=800" },
-  { id: 2, title: "七夕茶会", description: "星月夜に愉しむ夜茶の会", imageUrl: "/placeholder.svg?height=600&width=800" },
-  { id: 3, title: "中国茶藝の会", description: "千年の歴史が紡ぐ茶の世界", imageUrl: "/placeholder.svg?height=600&width=800" },
-  { id: 4, title: "涼煎茶の会", description: "清涼な一煎に夏の暑さを忘れる", imageUrl: "/placeholder.svg?height=600&width=800" },
+  { id: 1, title: "新緑の茶会", description: "桜の香り漂う、静寂の一服", imageUrl: "https://tea-app-sample-pic.s3.ap-northeast-1.amazonaws.com/tea-app-sample-1.jpg" },
+  { id: 2, title: "七夕茶会", description: "星月夜に愉しむ夜茶の会", imageUrl: "https://tea-app-sample-pic.s3.ap-northeast-1.amazonaws.com/tea-app-sample-2.jpg" },
+  { id: 3, title: "中国茶藝の会", description: "千年の歴史が紡ぐ茶の世界", imageUrl: "https://tea-app-sample-pic.s3.ap-northeast-1.amazonaws.com/tea-app-sample-3.jpg" },
+  { id: 4, title: "涼煎茶の会", description: "清涼な一煎に夏の暑さを忘れる", imageUrl: "https://tea-app-sample-pic.s3.ap-northeast-1.amazonaws.com/tea-app-sample-4.jpg" },
 ]
 
 export function TeaPartyGallery() {


### PR DESCRIPTION
## 概要

- 茶会詳細ページの画像をS3ホスティングの実際のサンプル画像に更新
- TeaPartyGalleryコンポーネントの画像も同様に更新
- 戻るリンクの遷移先を / から /history に修正

## 関連issue

https://github.com/sugawara-kazuya/reservation-tea-app/issues/78